### PR TITLE
Update constants.md

### DIFF
--- a/docs/csharp/programming-guide/classes-and-structs/constants.md
+++ b/docs/csharp/programming-guide/classes-and-structs/constants.md
@@ -61,7 +61,7 @@ ms.lasthandoff: 03/13/2017
   
  Константы могут иметь пометку [public](../../../csharp/language-reference/keywords/public.md), [private](../../../csharp/language-reference/keywords/private.md), [protected](../../../csharp/language-reference/keywords/protected.md), [internal](../../../csharp/language-reference/keywords/internal.md) или `protected``internal`. Эти модификаторы доступа определяют, каким образом пользователи класса смогут получать доступ к константе. Дополнительные сведения см. в разделе [Модификаторы доступа](../../../csharp/programming-guide/classes-and-structs/access-modifiers.md).  
   
- Доступ к константам осуществляется так, как если бы они были [статическими](../../../csharp/language-reference/keywords/static.md) полями, поскольку значение константы одинаково для всех экземпляров типа. Для их объявления используйте ключевое слово `static`. Выражения, которые не относятся к классу, определяющему константу, должны включать имя класса, период и имя константы для доступа к этой константе. Пример:  
+ Доступ к константам осуществляется так, как если бы они были [статическими](../../../csharp/language-reference/keywords/static.md) полями, поскольку значение константы одинаково для всех экземпляров типа. Для их объявления Вам не надо использовать ключевое слово `static`. Выражения, которые не относятся к классу, определяющему константу, должны включать имя класса, точку и имя константы для доступа к этой константе. Пример:  
   
  [!code-cs[csProgGuideObjects#67](../../../csharp/programming-guide/classes-and-structs/codesnippet/CSharp/constants_4.cs)]  
   


### PR DESCRIPTION
1) Заменил предложение "Для их объявления используйте ключевое слово static." на "Для их объявления Вам не надо использовать ключевое слово `static`.". Оригинал "You do not use the static keyword to declare them.".
2)  В предложении "Выражения, которые не относятся к классу, определяющему константу, должны включать имя класса, период и имя константы для доступа к этой константе." заменил "период" на "точку".