### PR TITLE
Fix typo in Mutex section

### DIFF
--- a/docs/standard/threading/overview-of-synchronization-primitives.md
+++ b/docs/standard/threading/overview-of-synchronization-primitives.md
@@ -65,7 +65,7 @@ ms.locfileid: "55479791"
 
 ### <a name="mutex-class"></a>Mutex - класс
 
-Как и <xref:System.Threading.Mutex?displayProperty=nameWithType>, класс <xref:System.Threading.Monitor> предоставляет монопольный доступ к общему ресурсу. С помощью вызова одной из перегрузок метода [Mutex.WaitOne](<xref:System.Threading.WaitHandle.WaitOne%2A?displayProperty=nameWithType>) можно запросить владение мьютексом. Как и <xref:System.Threading.Monitor>, <xref:System.Threading.Mutex> реализует привязку потока и поток, который получил мьютекс, должен освободить его, вызвав метод <xref:System.Threading.Mutex.ReleaseMutex%2A?displayProperty=nameWithType>.
+Как и <xref:System.Threading.Monitor>, класс <xref:System.Threading.Mutex?displayProperty=nameWithType> предоставляет монопольный доступ к общему ресурсу. С помощью вызова одной из перегрузок метода [Mutex.WaitOne](<xref:System.Threading.WaitHandle.WaitOne%2A?displayProperty=nameWithType>) можно запросить владение мьютексом. Как и <xref:System.Threading.Monitor>, <xref:System.Threading.Mutex> реализует привязку потока и поток, который получил мьютекс, должен освободить его, вызвав метод <xref:System.Threading.Mutex.ReleaseMutex%2A?displayProperty=nameWithType>.
 
 В отличие от <xref:System.Threading.Monitor>, класс <xref:System.Threading.Mutex> может использоваться для внутрипроцессной синхронизации. Для этого нужно использовать именованный мьютекс, который виден в операционной системе. Чтобы создать экземпляр именованного мьютекса, используйте [конструктор Mutex](<xref:System.Threading.Mutex.%23ctor%2A>), который задает имя. Также можно вызвать метод <xref:System.Threading.Mutex.OpenExisting%2A?displayProperty=nameWithType>, чтобы открыть существующий именованный системный мьютекс.
   


### PR DESCRIPTION
Swap links of the Monitor and the Mutex classes at the beginning of Mutex section overview-of-synchronization-primitives.md.