### PR TITLE
Fix class.md

### DIFF
--- a/docs/csharp/language-reference/keywords/class.md
+++ b/docs/csharp/language-reference/keywords/class.md
@@ -14,7 +14,7 @@ ms.contentlocale: ru-RU
 ms.lasthandoff: 03/14/2020
 ms.locfileid: "77673099"
 ---
-# <a name="class-c-reference"></a>класс (Справочник по C#)
+# <a name="class-c-reference"></a>class (Справочник по C#)
 
 Классы объявляются с помощью ключевого слова `class`, как показано в следующем примере:
 


### PR DESCRIPTION
Исправил заголовок статьи "класс" -> "class", т.к. речь идёт о ключевом слове, которое не должно переводиться. 
**Примеры других статей из того же раздела, в заголовке которых ключевое слово не переводится:**
https://docs.microsoft.com/ru-ru/dotnet/csharp/language-reference/keywords/interface
https://docs.microsoft.com/ru-ru/dotnet/csharp/language-reference/keywords/var